### PR TITLE
Changed condition check of block class

### DIFF
--- a/build/app/code/community/Symmetrics/TweaksGerman/Model/Observer.php
+++ b/build/app/code/community/Symmetrics/TweaksGerman/Model/Observer.php
@@ -100,7 +100,7 @@ class Symmetrics_TweaksGerman_Model_Observer
             $additionalInfoFlag = true;
 
         // Other product types
-        } elseif (get_class($block) == 'Mage_Catalog_Block_Product_Price' && trim($html)) {
+        } elseif ($block instanceof Mage_Catalog_Block_Product_Price && trim($html)) {
             $additionalInfoFlag = true;
         }
 


### PR DESCRIPTION
It is better to check if the block is an instance of Mage_Catalog_Block_Product_Price instead of checking equality of strings, so we consider future class inheritances.